### PR TITLE
Add jQuery Migrate 1.4.1 & 3.1.0 to fix addon ajax

### DIFF
--- a/headerHtml.inc.php
+++ b/headerHtml.inc.php
@@ -49,6 +49,8 @@ $headertext=<<<HTML1
 <link rel="stylesheet" href="themes/{$_SESSION['theme']}/style_screen.css" type="text/css" media="screen" />
 <link rel="shortcut icon" href="./favicon.ico" />
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-migrate-1.4.1.min.js" integrity="sha256-SOuLUArmo4YXtXONKz+uxIGSKneCJG4x0nVcA0pFzV0=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-migrate-3.1.0.min.js" integrity="sha256-ycJeXbll9m7dHKeaPbXBkZH8BuP99SmPm/8q5O+SbBc=" crossorigin="anonymous"></script>
 <script type="text/javascript" src="calendar.js"></script>
 <script type="text/javascript" src="lang/calendar-en.js"></script>
 <script type="text/javascript" src="gtdfuncs.js"></script>


### PR DESCRIPTION
Fixes the built-in addon ajax by first adding jQuery Migrate 1.4.1 and than adding jQuery Migrate 3.1.0. Both are needed as explained on jquery/jquery-migrate

# Background

The merged pull request #3 updates jQuery but breaks the built in addon "ajax", since some old jQuery functions are not available in the new  jQuery version.